### PR TITLE
Simple_router.p4 didn't compile due to missing includes. Also implementation of issue #1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,21 +42,21 @@ If you want to reproduce the results shown in the paper this virtual machine is 
 ## Run
 * Run Mininet with the P4(bmv2) CoDel implementation
 ```
-./run.sh [--nocli, --nopcap]
+./run.sh [--nocli, --nopcap, --iperft N]
 ```
 Normally this script generates PCAP files for evaluation and enters the Mininet CLI mode for debugging.
 With the optional command line parameters, this behavior can be changed.
 * Run Mininet with a simple P4(bmv2) router (fixed-sized FIFO)
 ```
-./simple_run.sh [--nocli, --nopcap]
+./simple_run.sh [--nocli, --nopcap, --iperft N]
 ```
 * Run Mininet with the Linux kernel CoDel implementation
 ```
-./linux_run.sh [--nocli, --nopcap]
+./linux_run.sh [--nocli, --nopcap, --iperft N]
 ```
 * Run Mininet with the P4(bmv2) CoDel implementation with different RTTs
 ```
-./rtt_run.sh [--nocli, --nopcap]
+./rtt_run.sh [--nocli, --nopcap, --iperft N]
 ```
 
 ## Evaluate

--- a/eval_scripts/plotting.py
+++ b/eval_scripts/plotting.py
@@ -264,7 +264,7 @@ def plotPcapQueueDelay(trace):
         y_values.append(y_val)
 
     plt.plot(x_values, y_values)
-    plt.plot([0, 10.2], [5, 5], '--', color='C5')
+    plt.plot([0, x_values[len(x_values) - 1] + 0.2], [5, 5], '--', color='C5')
     plt.ylabel('queue delay [ms]')
     plt.xlabel('time [s]')
     if not noTitle:

--- a/linux_run.sh
+++ b/linux_run.sh
@@ -18,8 +18,28 @@ if [ "$1" = "--nopcap" ] || [ "$1" = "--nocli" ]; then
   argsCommand=$1" True"
 fi
 
+if [ "$1" = "--iperft" ]; then 
+  argsCommand="--iperft "$2
+fi
+
 if [ "$2" = "--nopcap" ] || [ "$2" = "--nocli" ]; then
   argsCommand=$argsCommand" "$2" True"
+fi
+
+if [ "$2" = "--iperft" ]; then 
+  argsCommand=$argsCommand" --iperft "$3
+fi
+
+if [ "$3" = "--nopcap" ] || [ "$3" = "--nocli" ]; then
+  argsCommand=$argsCommand" "$3" True"
+fi
+
+if [ "$3" = "--iperft" ]; then 
+  argsCommand=$argsCommand" --iperft "$4
+fi
+
+if [ "$4" = "--nopcap" ] || [ "$4" = "--nocli" ]; then
+  argsCommand=$argsCommand" "$4" True"
 fi
 
 #delete old pcap files

--- a/rtt_run.sh
+++ b/rtt_run.sh
@@ -18,9 +18,30 @@ if [ "$1" = "--nopcap" ] || [ "$1" = "--nocli" ]; then
   argsCommand=$1" True"
 fi
 
+if [ "$1" = "--iperft" ]; then 
+  argsCommand="--iperft "$2
+fi
+
 if [ "$2" = "--nopcap" ] || [ "$2" = "--nocli" ]; then
   argsCommand=$argsCommand" "$2" True"
 fi
+
+if [ "$2" = "--iperft" ]; then 
+  argsCommand=$argsCommand" --iperft "$3
+fi
+
+if [ "$3" = "--nopcap" ] || [ "$3" = "--nocli" ]; then
+  argsCommand=$argsCommand" "$3" True"
+fi
+
+if [ "$3" = "--iperft" ]; then 
+  argsCommand=$argsCommand" --iperft "$4
+fi
+
+if [ "$4" = "--nopcap" ] || [ "$4" = "--nocli" ]; then
+  argsCommand=$argsCommand" "$4" True"
+fi
+
 
 #compile p4 file
 [ -e router_compiled.json ] && sudo rm -f router_compiled.json
@@ -39,11 +60,11 @@ do
   sudo mn -c
   #start mininet environment
   sudo PYTHONPATH=$PYTHONPATH:../behavioral-model/mininet/ \
-      python toposetup.py \
-      --switch simple_switch -p4 \
-      --json ./router_compiled.json \
+      python srcPython/toposetup.py \
+      --swpath ../behavioral-model/targets/simple_switch/simple_switch \
+      --json ./router_compiled.json -p4 \
       --cli simple_switch_CLI \
-      --cliCmd commandsRouter1.txt \
+      --cliCmd commandsCodelRouter.txt \
       $argsCommand \
       --h3delay $i"ms"
   filename="iperf_output"$i".json"

--- a/run.sh
+++ b/run.sh
@@ -18,9 +18,30 @@ if [ "$1" = "--nopcap" ] || [ "$1" = "--nocli" ]; then
   argsCommand=$1" True"
 fi
 
+if [ "$1" = "--iperft" ]; then 
+  argsCommand="--iperft "$2
+fi
+
 if [ "$2" = "--nopcap" ] || [ "$2" = "--nocli" ]; then
   argsCommand=$argsCommand" "$2" True"
 fi
+
+if [ "$2" = "--iperft" ]; then 
+  argsCommand=$argsCommand" --iperft "$3
+fi
+
+if [ "$3" = "--nopcap" ] || [ "$3" = "--nocli" ]; then
+  argsCommand=$argsCommand" "$3" True"
+fi
+
+if [ "$3" = "--iperft" ]; then 
+  argsCommand=$argsCommand" --iperft "$4
+fi
+
+if [ "$4" = "--nopcap" ] || [ "$4" = "--nocli" ]; then
+  argsCommand=$argsCommand" "$4" True"
+fi
+
 
 #compile p4 file
 [ -e router_compiled.json ] && sudo rm -f router_compiled.json

--- a/simple_run.sh
+++ b/simple_run.sh
@@ -18,9 +18,30 @@ if [ "$1" = "--nopcap" ] || [ "$1" = "--nocli" ]; then
   argsCommand=$1" True"
 fi
 
+if [ "$1" = "--iperft" ]; then 
+  argsCommand="--iperft "$2
+fi
+
 if [ "$2" = "--nopcap" ] || [ "$2" = "--nocli" ]; then
   argsCommand=$argsCommand" "$2" True"
 fi
+
+if [ "$2" = "--iperft" ]; then 
+  argsCommand=$argsCommand" --iperft "$3
+fi
+
+if [ "$3" = "--nopcap" ] || [ "$3" = "--nocli" ]; then
+  argsCommand=$argsCommand" "$3" True"
+fi
+
+if [ "$3" = "--iperft" ]; then 
+  argsCommand=$argsCommand" --iperft "$4
+fi
+
+if [ "$4" = "--nopcap" ] || [ "$4" = "--nocli" ]; then
+  argsCommand=$argsCommand" "$4" True"
+fi
+
 
 #compile p4 file
 [ -e router_compiled.json ] && rm router_compiled.json

--- a/srcP4/codel.p4
+++ b/srcP4/codel.p4
@@ -39,20 +39,7 @@ header_type codel_t {
     }
 }
 
-header_type queueing_metadata_t {
-    fields {
-        enq_timestamp : 48;
-        enq_qdepth : 16;
-        deq_timedelta : 32;
-        deq_qdepth : 16;
-        qid : 8;
-    }
-}
-
-
 metadata codel_t codel;
-metadata queueing_metadata_t queueing_metadata;
-
 
 action a_codel_init() {
     //for debugging

--- a/srcP4/header.p4
+++ b/srcP4/header.p4
@@ -71,3 +71,13 @@ header_type queue_delay_t {
 	}
 }
 
+header_type queueing_metadata_t {
+    fields {
+        enq_timestamp : 48;
+        enq_qdepth : 16;
+        deq_timedelta : 32;
+        deq_qdepth : 16;
+        qid : 8;
+    }
+}
+

--- a/srcP4/router.p4
+++ b/srcP4/router.p4
@@ -28,6 +28,7 @@ header ipv4_t ipv4;
 header udp_t udp;
 header tcp_t tcp;
 header tcp_opt_t tcp_options;
+metadata queueing_metadata_t queueing_metadata;
 
 /////////////////////////////////
 //        begin parser         //

--- a/srcP4/simple_router.p4
+++ b/srcP4/simple_router.p4
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+#define add_queue_delay
 
 #include "header.p4"
 
@@ -26,6 +27,10 @@
 /////////////////////////////////
 header ipv4_t ipv4;
 header ethernet_t ethernet;
+header udp_t udp;
+header tcp_t tcp;
+header tcp_opt_t tcp_options;
+metadata queueing_metadata_t queueing_metadata;
 
 parser start {
 	extract(ethernet);

--- a/srcPython/ping.py
+++ b/srcPython/ping.py
@@ -17,10 +17,10 @@ import time
 import os, sys, glob
 
 class IperfTest():
-    def IperfTest(self, a, b, c, d):
+    def IperfTest(self, a, b, c, d, transmit_time):
         #self.startPingTest(c, d)
         #time.sleep(2)
-        self.startIperfTest(a, b)
+        self.startIperfTest(a, b, transmit_time)
         #time.sleep(1)
         #self.stopPingTest(c)
         self.copyFiles()
@@ -30,11 +30,12 @@ class IperfTest():
             os.rename(file, "out/"+file)
 
     # data are transmitted from a to b
-    def startIperfTest(self, a, b):
+    def startIperfTest(self, a, b, transmit_time):
         cmd1 = ["iperf3", "-s", "&"]
         b.cmd(cmd1)
         print('start iperf3 test')
-        cmd2 = ["iperf3", "-c", str(b.IP()), "-J", "-t 10", "-i 0.1", "-P 1"]
+        cmd2 = ["iperf3", "-c", str(b.IP()), "-J", "-t " + str(transmit_time), "-i 0.1", "-P 1"]
+	print(cmd2)
         out = a.cmd(cmd2)
         b.sendInt()
 	print("finished iperf3 test")

--- a/srcPython/toposetup.py
+++ b/srcPython/toposetup.py
@@ -55,6 +55,9 @@ parser.set_defaults(nocli=False)
 parser.add_argument('--h3delay', help='The delay between h3 and s2. Example: "30ms"',
                     type=str, action="store")
 parser.set_defaults(h3delay="2ms")
+parser.add_argument('--iperft', help='The transmit time of iperf3 in seconds. Example: 30',
+                    type=int, action="store")
+parser.set_defaults(iperft=10)
 
 args = parser.parse_args()
 
@@ -177,7 +180,7 @@ def main():
     sleep(1)
 
     print "Now the iperf test starts !"
-    iperfTest.IperfTest(mn.getNodeByName('h1'), mn.getNodeByName('h3'), mn.getNodeByName('h2'), mn.getNodeByName('h4'))
+    iperfTest.IperfTest(mn.getNodeByName('h1'), mn.getNodeByName('h3'), mn.getNodeByName('h2'), mn.getNodeByName('h4'), args.iperft)
     if not args.nocli:
         CLI( mn )
     mn.stop()


### PR DESCRIPTION
Fixed problems with simple_router.p4. Refactored header.p4 so simple_router.p4 can use add_queue_delay. This is necessary to show the queue delay in the corresponding plot.
The second commit implements the new feature from issue #1. 